### PR TITLE
googleApiKey is not being passed down

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,5 @@ build/
 
 pubspec.lock
 lib/src/Constants.dart
-lib/src/constants.dart
 example/lib/Constants.dart
 .fvm

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:google_maps_flutter/google_maps_flutter.dart';
-
 import 'package:flutter_polyline_points/flutter_polyline_points.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 void main() => runApp(MyApp());
 
@@ -98,12 +97,21 @@ class _MapScreenState extends State<MapScreen> {
   }
 
   _getPolyline() async {
+    PolylineRequest request = PolylineRequest(
+      origin: PointLatLng(_originLatitude, _originLongitude),
+      destination: PointLatLng(_destLatitude, _destLongitude),
+      mode: TravelMode.driving,
+      wayPoints: [PolylineWayPoint(location: "Sabo, Yaba Lagos Nigeria")],
+      avoidHighways: false,
+      avoidTolls: false,
+      avoidFerries: false,
+      optimizeWaypoints: false,
+      alternatives: false,
+    );
     PolylineResult result = await polylinePoints.getRouteBetweenCoordinates(
-        googleAPiKey,
-        PointLatLng(_originLatitude, _originLongitude),
-        PointLatLng(_destLatitude, _destLongitude),
-        travelMode: TravelMode.driving,
-        wayPoints: [PolylineWayPoint(location: "Sabo, Yaba Lagos Nigeria")]);
+      request: request,
+      googleApiKey: googleAPiKey,
+    );
     if (result.points.isNotEmpty) {
       result.points.forEach((PointLatLng point) {
         polylineCoordinates.add(LatLng(point.latitude, point.longitude));

--- a/lib/flutter_polyline_points.dart
+++ b/lib/flutter_polyline_points.dart
@@ -27,8 +27,8 @@ class PolylinePoints {
             (request.proxy != null && googleApiKey == null),
         "Google API Key cannot be empty if proxy isn't provided");
     try {
-      var result =
-          await NetworkUtil().getRouteBetweenCoordinates(request: request);
+      var result = await NetworkUtil().getRouteBetweenCoordinates(
+          request: request, googleApiKey: googleApiKey);
       return result.isNotEmpty
           ? result[0]
           : PolylineResult(errorMessage: "No result found");

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -1,0 +1,4 @@
+class Constants {
+  // Replace with your API key, required for tests and example
+  static const String API_KEY = "YOUR_API_KEY";
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  http: ^1.0.0
+  http: ^1.2.1
 
 dev_dependencies:
   flutter_test:

--- a/test/flutter_polyline_points_test.dart
+++ b/test/flutter_polyline_points_test.dart
@@ -1,15 +1,25 @@
+import 'package:flutter_polyline_points/flutter_polyline_points.dart';
 import 'package:flutter_polyline_points/src/constants.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'package:flutter_polyline_points/flutter_polyline_points.dart';
 
 void main() {
   test('get list of coordinates from two geographical positions', () async {
     final polylinePoints = PolylinePoints();
+    final request = PolylineRequest(
+      origin: PointLatLng(6.5212402, 3.3679965),
+      destination: PointLatLng(6.595680, 3.337030),
+      mode: TravelMode.driving,
+      wayPoints: [],
+      avoidHighways: false,
+      avoidTolls: false,
+      avoidFerries: false,
+      optimizeWaypoints: false,
+      alternatives: false,
+    );
     PolylineResult result = await polylinePoints.getRouteBetweenCoordinates(
-        Constants.API_KEY, PointLatLng(6.5212402, 3.3679965),
-        PointLatLng(6.595680, 3.337030),
-        travelMode: TravelMode.driving);
+      request: request,
+        googleApiKey: Constants.API_KEY,
+        );
     assert(result.points.isNotEmpty == true);
   });
 


### PR DESCRIPTION
Your proposed fix of multipoint distance and duration calculations is fantastic but it is not working as is. You need to pass the apikey all the way into the implementation in order to get a valid result from the api. Small change but vital.

Since you changed the interface of PolylinePoints().getRouteBetweenCoordinates() you should also update the example and tests to match the new signature. This part is not vital but might help to get your PR approved.

Personally, I am not a fan of changing getRouteBetweenCoordinates() to take a PolylineRequest object rather than individual parameters, as it forces the caller to use the internal  PolylineRequest. But that's your decision. 😎 